### PR TITLE
Update example to use reverse port forwarding 

### DIFF
--- a/TestAlttrashCSharp/tests/BaseTest.cs
+++ b/TestAlttrashCSharp/tests/BaseTest.cs
@@ -33,7 +33,6 @@ namespace alttrashcat_tests_csharp.tests
             _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(60);
             Thread.Sleep(30000);
             Console.WriteLine("Appium driver started");
-            SetupPortForwarding();
         }
 
         [OneTimeTearDown]
@@ -43,11 +42,5 @@ namespace alttrashcat_tests_csharp.tests
             _driver.Quit();
         }
 
-        void SetupPortForwarding()
-        {
-            AltPortForwarding.KillAllIproxyProcess();
-            AltPortForwarding.ForwardIos();
-            Console.WriteLine("Port forwarded (iOS).");
-        }
     }
 }


### PR DESCRIPTION
What was made in this PR:
- removed all port forwarding methods since `port forwarding` is no more possible on iOS devices
- inform the users about the workaround -> a link will be added to the docs in https://github.com/alttester/EXAMPLES-CSharp-iOS-AltTrahCat/pull/6